### PR TITLE
Create setup.py and make ancillary changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 #
+# Ignore cached Python byte code
+# 
+__pycache__
+
+#
 # Ignore large Magenta models aka bundles aka mag files
 #
 *.mag

--- a/EasyMusicGenerator/EasyMusicGenerator.py
+++ b/EasyMusicGenerator/EasyMusicGenerator.py
@@ -1,7 +1,3 @@
-"""This is the main module for EasyMusicGenerator
-"""
-__version__ = '0.1.0'
-
 import Preprocessor as pp
 import Pregenerator as pg
 #import Generator as gen

--- a/EasyMusicGenerator/__init__.py
+++ b/EasyMusicGenerator/__init__.py
@@ -1,0 +1,6 @@
+
+from .__version import __version__
+
+
+# --- END --- #
+

--- a/EasyMusicGenerator/__version.py
+++ b/EasyMusicGenerator/__version.py
@@ -1,0 +1,4 @@
+"""This module defines the version for the package.
+"""
+__version__ = '0.1.0'
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ The requirements for the project are described [here][project-info]
 [access required].
 
 
+# Installation #
+
+Clone this repository to your local computer.
+
+    git clone https://github.com/PrestonStringham/DATA515-MusicGeneration
+
+Change directories to the local copy of the repo.
+
+    cd DATA515-MusicGeneration
+
+Install using the following PIP command line.
+
+    pip install -e .
+
+
 [project-info]:https://canvas.uw.edu/courses/1434044/pages/project-infomation
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
+numpy==1.20
+scipy
+pandas
+scikit-learn
 matplotlib==3.3.4
-numpy==1.19.5
+seaborn
+magenta
 music21==6.7.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-numpy==1.20
-scipy
-pandas
-scikit-learn
-matplotlib 
-seaborn
-magenta
-music21
-
+matplotlib==3.3.4
+numpy==1.19.5
+music21==6.7.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+"""
+This is the setup.py file for EasyMusicGenerator.
+See the README.md file in the root of this repo
+for instruction to install this module.
+"""
+
+from setuptools import setup, find_packages
+
+setup(
+    name='EasyMusicGenerator',
+    version='0.1.0',
+    packages=find_packages(include=['EasyMusicGenerator',
+                                    'Preprocessor',
+                                    'Pregenerator',
+                                    ]),
+    install_requires=[
+        'matplotlib==3.3.4',
+        'numpy==1.19.5',
+        'music21==6.7.0',
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,13 @@ setup(
                                     'Pregenerator',
                                     ]),
     install_requires=[
+        'numpy==1.20',
+        'scipy',
+        'pandas',
+        'scikit-learn',
         'matplotlib==3.3.4',
-        'numpy==1.19.5',
+        'seaborn',
+        'magenta',
         'music21==6.7.0',
     ]
 )

--- a/tests/emg-import-test.py
+++ b/tests/emg-import-test.py
@@ -1,0 +1,7 @@
+import EasyMusicGenerator as emg
+
+print( emg.__version__ )
+
+
+# --- END --- #
+


### PR DESCRIPTION
See the top-level README.md for instructions to install the package.

I initially put the version string in EasyMusicGenerator.py, but after module installation, I had trouble importing it from there because of EasyMusicGenerator's dependencies on Preprocessor.py and Pregenerator.py. I'm not sure exactly what the issue was there, but to work around it, I put the version string in its own module--at least for now.

I added a short Python program in the `tests` directory. After you install the package, you can use this program to test that you can import the package and view the version string.