### PR TITLE
Fix pylint issues with top-level __init__.py

### DIFF
--- a/EasyMusicGenerator/__init__.py
+++ b/EasyMusicGenerator/__init__.py
@@ -1,6 +1,4 @@
-
-from .__version import __version__
+"""Top-level __init__.py for EasyMusicGenerator
+"""
 from Preprocessor import *
-
-# --- END --- #
-
+from .__version import __version__


### PR DESCRIPTION
Fix the following issues reported by pylint:

    C0305: Trailing newlines (trailing-newlines)
    ************* Module EasyMusicGenerator

    C0114: Missing module docstring
    (missing-module-docstring)

    C0411: first party import "from Preprocessor import *"
    should be placed before "from .__version import __version__"
    (wrong-import-order)

The following issue continues to be reported by pylint:

    C0103: Module name "EasyMusicGenerator" doesn't conform
    to snake_case naming style (invalid-name)