### PR TITLE
Setup Travis to do code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ python:
   - "3.8"
 before_install: 
   - sudo apt-get install -y libasound2-dev
-script: 
+
+#
+# List of commands to run before the main script
+#
+before_script: 
  - flake8 easy_music_generator/__init__.py
- - cd easy_music_generator && python -m unittest discover
+
+script: 
+ - cd easy_music_generator && coverage run -m unittest discover
+
+after_success:
+  - coverage report
+  - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ seaborn
 magenta
 music21==6.7.0
 flake8
+coverage
+coverall

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ magenta
 music21==6.7.0
 flake8
 coverage
-coverall
+coveralls


### PR DESCRIPTION
**Set up code coverage in our Travis builds.**

TBH, I am not sure what this buys us. The reason is that the Travis report apparently doesn't include output that is sent to `stdout`. It show only output that is sent to `stderr`, which means that we can't actually see the coverage results in the Travis report.

Nevertheless, the instructor had this configuration in her `.travis.yml`--and it doesn't cause any issues--so I am using it here.