### PR TITLE
Minor updates to the `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 #
-# Ignore cached Python byte code
+# The SQLite database used by Coverage
+#
+.coverage
+
+#
+# Output files from Easy Music Generator
+#
+easy_music_generator/output/*
+
+#
+# Cached Python byte code
 #
 __pycache__
 


### PR DESCRIPTION
Ignore the following:

- The SQLite database used by Coverage (`.coverage`)
- EasyMusicGenerator's output files in the `easy_music_generator/output` directory