### PR TITLE
Fix build break: Run unit tests from the top of the repo (rather than the package directory)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
  - flake8 easy_music_generator/__init__.py
 
 script: 
- - cd easy_music_generator && coverage run -m unittest discover
+ - coverage run -m unittest discover
 
 after_success:
   - coverage report

--- a/easy_music_generator/__init__.py
+++ b/easy_music_generator/__init__.py
@@ -1,10 +1,15 @@
 """Top-level __init__.py for EasyMusicGenerator
 """
-from easy_music_generator.preprocessor.chord_distribution import (ChordDistribution,
-                                             NoChordsFoundException)
-from easy_music_generator.preprocessor.note_distribution import (NoteDistribution,
-                                            NoNotesFoundException)
-from easy_music_generator.preprocessor.preprocessor import Preprocessor, NoFilesFoundException
+
+from easy_music_generator.preprocessor.chord_distribution import (
+    ChordDistribution)
+
+from easy_music_generator.preprocessor.note_distribution import (
+    NoteDistribution, NoNotesFoundException)
+
+from easy_music_generator.preprocessor.preprocessor import (
+    Preprocessor, NoFilesFoundException)
+
 from .__version import __version__
 
 __all__ = [ChordDistribution, NoNotesFoundException, NoteDistribution,

--- a/easy_music_generator/preprocessor/tests/test_chord_distribution.py
+++ b/easy_music_generator/preprocessor/tests/test_chord_distribution.py
@@ -1,5 +1,5 @@
 import unittest
-import preprocessor.chord_distribution as cd
+from easy_music_generator.preprocessor import chord_distribution as cd
 import music21 as mus
 
 

--- a/easy_music_generator/preprocessor/tests/test_note_distribution.py
+++ b/easy_music_generator/preprocessor/tests/test_note_distribution.py
@@ -1,5 +1,5 @@
 import unittest
-import preprocessor.note_distribution as nd
+from easy_music_generator.preprocessor import note_distribution as nd
 import numpy as np
 import music21 as mus
 
@@ -43,7 +43,7 @@ class TestNoteDistribution(unittest.TestCase):
         Test that get_note_matrix() raises an exception when the score
         object it gets does not contain any notes
         '''
-        score = mus.converter.parse('./music/test_no_notes_exception.xml')
+        score = mus.converter.parse('./easy_music_generator/music/test_no_notes_exception.xml')
         with self.assertRaises(nd.NoNotesFoundException) as context:
             nd.NoteDistribution.get_note_matrix([score])
 

--- a/easy_music_generator/preprocessor/tests/test_preprocessor.py
+++ b/easy_music_generator/preprocessor/tests/test_preprocessor.py
@@ -1,5 +1,5 @@
 import unittest
-import preprocessor.preprocessor as p
+from easy_music_generator.preprocessor import preprocessor as p
 
 
 class TestPreprocessor(unittest.TestCase):
@@ -11,7 +11,8 @@ class TestPreprocessor(unittest.TestCase):
         '''
 
         preprocessor_obj = p.Preprocessor()
-        score = preprocessor_obj.parse_scores("./music/test_parse_scores/")
+        score = preprocessor_obj.parse_scores(
+                "./easy_music_generator/music/test_parse_scores/")
 
         self.assertEqual("<class 'list'>", str(type(score)))
 

--- a/easy_music_generator/tests/test_easy_music_generator.py
+++ b/easy_music_generator/tests/test_easy_music_generator.py
@@ -1,7 +1,7 @@
 import os
 import glob
 import unittest
-import easy_music_generator as emg
+from easy_music_generator import easy_music_generator as emg
 
 
 class TestEasyMusicGenerator(unittest.TestCase):
@@ -23,7 +23,12 @@ class TestEasyMusicGenerator(unittest.TestCase):
     def test_easy_music_generator(self):
         emg_obj = emg.EasyMusicGenerator()
 
-        emg_obj.analyze('music/')
-        emg_obj.generate(140, 10, 'output/')
+        input_file_path = './easy_music_generator/music/'
+        emg_obj.analyze(input_file_path)
+
+        output_file_path = 'output/'
+        number_of_bars = 10
+        emg_obj.generate(number_of_bars, output_file_path)
+
         out_midi = glob.glob('./output/*.mid')
         self.assertNotEqual(len(out_midi), 0)


### PR DESCRIPTION
This PR updates our unit tests so that they run from the top level of the repository instead of from the package directory.

This PR also includes flake8 fixes to our package-level `__init__.py`, that is, `easy_music_generator/__init__.py`. I incorporated these change from the following PR:

**Fix flake8 errors in package-level init #29**
`carljparker wants to merge 1 commit into main from carljparker/flake8-in-package-init`

I am discarding that PR because those changes are now included here.

As a result of recent changes, EMG now creates the `output` directory at the top of the repo instead of in the package directory. However, the `music` directory--that is, the _input_ directory--is still in the package directory. This feels a little asymmetrical to me, but I doubt it will create any issues when the package is evaluated. Unless otherwise directed, I'll document the current behavior in the functional spec.