### PR TITLE
Set up requires conda environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
  - flake8 easy_music_generator/__init__.py
 
 script: 
- - cd easy_music_generator && coverage run -m unittest discover
+ - coverage run -m unittest discover
 
 after_success:
   - coverage report

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ The requirements for the project are described [here][project-info]
 
 # Installation #
 
-Clone this repository to your local computer.
+The `pip` installer has difficulty installing some Python packages used
+for data science. We recommend that you create a custom conda
+environment using the provided `env-music-gen.yml` file.
+
+    conda env create -f env-music-gen.yml
+                                                           
+Activate the newly created conda environment, `music-gen-515`.
+
+    conda activate music-gen-515 
+
+Next, clone this repository to your local computer.
 
     git clone https://github.com/PrestonStringham/DATA515-MusicGeneration
 
@@ -18,11 +28,8 @@ Change directories to the local copy of the repo.
 
     cd DATA515-MusicGeneration
     
-Activate a base anaconda environment.
- 
-    conda activate
-
-Install using the following PIP command line.
+Install package--and remaining package requirements--using the following
+PIP command line.
 
     pip install .
 
@@ -37,7 +44,7 @@ Make sure that you are inside the DATA515-MusicGeneration directory before runni
 ```python 
 from easy_music_generator import easy_music_generator as emg
 emg_obj = emg.EasyMusicGenerator()
-input_file_path = 'music/'
+input_file_path = 'easy_music_generator/music/'
 emg_obj.analyze(input_file_path)
 output_file_path = 'output/'
 number_of_bars = 10

--- a/easy_music_generator/__init__.py
+++ b/easy_music_generator/__init__.py
@@ -1,10 +1,15 @@
 """Top-level __init__.py for EasyMusicGenerator
 """
-from easy_music_generator.preprocessor.chord_distribution import (ChordDistribution,
-                                             NoChordsFoundException)
-from easy_music_generator.preprocessor.note_distribution import (NoteDistribution,
-                                            NoNotesFoundException)
-from easy_music_generator.preprocessor.preprocessor import Preprocessor, NoFilesFoundException
+
+from easy_music_generator.preprocessor.chord_distribution import (
+    ChordDistribution)
+
+from easy_music_generator.preprocessor.note_distribution import (
+    NoteDistribution, NoNotesFoundException)
+
+from easy_music_generator.preprocessor.preprocessor import (
+    Preprocessor, NoFilesFoundException)
+
 from .__version import __version__
 
 __all__ = [ChordDistribution, NoNotesFoundException, NoteDistribution,

--- a/easy_music_generator/preprocessor/tests/test_chord_distribution.py
+++ b/easy_music_generator/preprocessor/tests/test_chord_distribution.py
@@ -1,5 +1,5 @@
 import unittest
-import preprocessor.chord_distribution as cd
+from easy_music_generator.preprocessor import chord_distribution as cd
 import music21 as mus
 
 

--- a/easy_music_generator/preprocessor/tests/test_note_distribution.py
+++ b/easy_music_generator/preprocessor/tests/test_note_distribution.py
@@ -1,5 +1,5 @@
 import unittest
-import preprocessor.note_distribution as nd
+from easy_music_generator.preprocessor import note_distribution as nd
 import numpy as np
 import music21 as mus
 
@@ -43,7 +43,7 @@ class TestNoteDistribution(unittest.TestCase):
         Test that get_note_matrix() raises an exception when the score
         object it gets does not contain any notes
         '''
-        score = mus.converter.parse('./music/test_no_notes_exception.xml')
+        score = mus.converter.parse('./easy_music_generator/music/test_no_notes_exception.xml')
         with self.assertRaises(nd.NoNotesFoundException) as context:
             nd.NoteDistribution.get_note_matrix([score])
 

--- a/easy_music_generator/preprocessor/tests/test_preprocessor.py
+++ b/easy_music_generator/preprocessor/tests/test_preprocessor.py
@@ -1,5 +1,5 @@
 import unittest
-import preprocessor.preprocessor as p
+from easy_music_generator.preprocessor import preprocessor as p
 
 
 class TestPreprocessor(unittest.TestCase):
@@ -11,7 +11,8 @@ class TestPreprocessor(unittest.TestCase):
         '''
 
         preprocessor_obj = p.Preprocessor()
-        score = preprocessor_obj.parse_scores("./music/test_parse_scores/")
+        score = preprocessor_obj.parse_scores(
+                "./easy_music_generator/music/test_parse_scores/")
 
         self.assertEqual("<class 'list'>", str(type(score)))
 

--- a/easy_music_generator/tests/test_easy_music_generator.py
+++ b/easy_music_generator/tests/test_easy_music_generator.py
@@ -1,7 +1,7 @@
 import os
 import glob
 import unittest
-import easy_music_generator as emg
+from easy_music_generator import easy_music_generator as emg
 
 
 class TestEasyMusicGenerator(unittest.TestCase):
@@ -23,7 +23,12 @@ class TestEasyMusicGenerator(unittest.TestCase):
     def test_easy_music_generator(self):
         emg_obj = emg.EasyMusicGenerator()
 
-        emg_obj.analyze('music/')
-        emg_obj.generate(140, 10, 'output/')
+        input_file_path = './easy_music_generator/music/'
+        emg_obj.analyze(input_file_path)
+
+        output_file_path = 'output/'
+        number_of_bars = 10
+        emg_obj.generate(number_of_bars, output_file_path)
+
         out_midi = glob.glob('./output/*.mid')
         self.assertNotEqual(len(out_midi), 0)

--- a/env-music-gen.yml
+++ b/env-music-gen.yml
@@ -1,0 +1,23 @@
+
+name: music-gen-515
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.7
+  - numpy
+  - scipy
+  - pandas
+  - scikit-learn=0.24
+  - matplotlib 
+  - seaborn
+  - typing_extensions  # needed for pytorch
+  - jupyter
+  - nb_conda_kernels
+  - ipykernel
+  - jupytext 
+
+
+# --- END --- #
+

--- a/env-music-gen.yml
+++ b/env-music-gen.yml
@@ -5,18 +5,13 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.7
+  - python=3.8
   - numpy
   - scipy
   - pandas
   - scikit-learn=0.24
   - matplotlib 
   - seaborn
-  - typing_extensions  # needed for pytorch
-  - jupyter
-  - nb_conda_kernels
-  - ipykernel
-  - jupytext 
 
 
 # --- END --- #


### PR DESCRIPTION
PIP has real issues when it comes to installing data science packages.

We need to fall back to a two-step install: First create a custom conda environment for the base data science packages. Then, use PIP to install the remaining requirements (`magenta` and `music21`) and our package.

This PR assumes the changes made in PR #30, so I am leaving this PR as a draft until PR #30 is merged.