### PR TITLE
Fix `setup.py` to actually find our packages and modules

### DIFF
--- a/easy_music_generator/__init__.py
+++ b/easy_music_generator/__init__.py
@@ -1,13 +1,13 @@
 """Top-level __init__.py for EasyMusicGenerator
 """
 
-from easy_music_generator.preprocessor.chord_distribution import (
+from .preprocessor.chord_distribution import (
     ChordDistribution)
 
-from easy_music_generator.preprocessor.note_distribution import (
+from .preprocessor.note_distribution import (
     NoteDistribution, NoNotesFoundException)
 
-from easy_music_generator.preprocessor.preprocessor import (
+from .preprocessor.preprocessor import (
     Preprocessor, NoFilesFoundException)
 
 from .__version import __version__

--- a/examples/example.py
+++ b/examples/example.py
@@ -4,5 +4,5 @@ sys.path.append('../')
 
 emg_obj = emg.EasyMusicGenerator()
 
-emg_obj.analyze('easy_music_generator/music/')
+emg_obj.analyze('music/')
 emg_obj.generate(10, 'output/')

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,8 @@ from setuptools import setup, find_packages
 setup(
     name='EasyMusicGenerator',
     version='0.1.0',
-    packages=find_packages(include=['EasyMusicGenerator',
-                                    'Preprocessor',
-                                    'Pregenerator',
+    packages=find_packages(include=['easy_music_generator',
+                                    'easy_music_generator.preprocessor',
                                     ]),
     install_requires=[
         'numpy==1.20',


### PR DESCRIPTION
I don't know how we got this far without discovering this issue . . . :-P

I was trying out our package this morning and discovered that I could not import our package from outside the repo. I investigated and discovered that our `setup.py` was still using the old CamelCase names for our packages. Therefore, our packages were never actually being added to Python's global package namespace (or whatever it is called).

The changes in this PR fix this issue. Note that after changing `setup.py`, I discovered that the imports in our top-level `__init.py__` no longer worked, evidently because they were prefixed with `easy_music_generator` which is now redundant because the `easy_music_generator` package is now visible everywhere.

With these changes, the following work from anywhere on my computer:

`import easy_music_generator`

and 

`from easy_music_generator import preprocessor`

Also, with these changes, _assuming that I have a `music` folder in the current directory_, I can run our `example.py` from outside the repo. In other words . . . 

```
(music-gen-515) --| ~/git/github-test  | 12:03:44 | Wed |--
[0][15293]>>> cp -rpv DATA515-MusicGeneration/examples/music .
DATA515-MusicGeneration/examples/music -> ./music
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V08.mxl -> ./music/BachJS-BWV988-V08.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V09.mxl -> ./music/BachJS-BWV988-V09.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-A.mxl -> ./music/BachJS-BWV988-A.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V14.mxl -> ./music/BachJS-BWV988-V14.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V13.mxl -> ./music/BachJS-BWV988-V13.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V07.mxl -> ./music/BachJS-BWV988-V07.mxl
DATA515-MusicGeneration/examples/music/beethoven_symphony_5_1_(c)galimberti.mid -> ./music/beethoven_symphony_5_1_(c)galimberti.mid
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V12.mxl -> ./music/BachJS-BWV988-V12.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V10.mxl -> ./music/BachJS-BWV988-V10.mxl
DATA515-MusicGeneration/examples/music/BachJS-BWV988-V11.mxl -> ./music/BachJS-BWV988-V11.mxl

(music-gen-515) --| ~/git/github-test  | 12:04:14 | Wed |--
[0][15294]>>> py3 ./DATA515-MusicGeneration/examples/example.py
Generated successfully!
```

While I was sorting all this out, I also noticed that we (probably _me_) added `easy_music_generator` to the path to `music` in `example.py`. I removed that because `example.py` should use the `music` folder in the `examples` directory, as described in our `README.md`.

Even though we are in the 11th hour, we should take these changes because the graders will almost certainly check to see if they can import our package outside of our repo to verify that our setup works correctly--which it currently does not . . . :-( 
