### PR TITLE
Copy mag file to install direction during setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include easy_music_generator/lakh2_polyphony_rnn.mag

--- a/easy_music_generator/easy_music_generator.py
+++ b/easy_music_generator/easy_music_generator.py
@@ -1,4 +1,4 @@
-import easy_music_generator.preprocessor.preprocessor as pp
+from easy_music_generator.preprocessor import preprocessor as pp
 import easy_music_generator.pregenerator as pg
 import subprocess
 import os
@@ -65,6 +65,7 @@ class EasyMusicGenerator:
             command = f'{command}'
             process = subprocess.Popen(command, shell=True,
                                        stdout=DEVNULL, stderr=DEVNULL)
+
             process.wait()
             print('Generated successfully!')
         except Exception:

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ from setuptools import setup, find_packages
 setup(
     name='EasyMusicGenerator',
     version='0.1.0',
+    include_package_data=True,
     packages=find_packages(include=['easy_music_generator',
                                     'easy_music_generator.preprocessor',
+                                    'easy_music_generator.pregenerator',
                                     ]),
     install_requires=[
         'numpy==1.20',


### PR DESCRIPTION
How does it come to this . . . ?

Earlier today, Andreia asked if--with my earlier changes to setup--a MIDI file was still being created. I said yes. I realize now that was untrue. I must have been looking at a MIDI file that was generated from an earlier run. I assumed that it was recent because I saw the "Generated successfully!" message. That message was, sadly, also untrue.

It turns out that we were not copying our MAG file to the installation directory during setup. Therefore, it was not available when running our package outside of the repo. However, in this scenario, our package still prints the "Generated successfully!" message. The unit tests were all running fine because they were using the MAG file inside the repo.

Again, I discovered all this earlier this evening while playing around with setup and testing the package . . . :-P

This PR creates a `MANIFEST.in` file that specifies for the MAG file to be copied during setup. I also needed to add the following line to `setup.py`:

    include_package_data=True

In addition, I had to make yet another adjustment to our import statements in `easy_music_generator`.

Now, everything is running as it was earlier today, but now we are getting the MIDI output.
